### PR TITLE
ci: Move away from unmaintained actions-rs/toolchain

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -32,12 +32,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: clippy
-          override: true
+        run: |
+          rustup update stable
+          rustup default stable
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,10 +25,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+          rustup update stable
+          rustup default stable
       - name: Test judge-client-3
         run: |
           cd mocktest


### PR DESCRIPTION
The actions-rs/toolchain action uses the deprecated set-output command and it'll be removed in the future.  Also the entire actions-rs organization has been archived, indicating the action isn't maintained anymore.

Link: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/